### PR TITLE
test: add unit tests for TabOption component

### DIFF
--- a/src/components/atoms/TabGroup/TabOption.test.tsx
+++ b/src/components/atoms/TabGroup/TabOption.test.tsx
@@ -1,0 +1,149 @@
+import '@testing-library/jest-dom';
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import TabOption from './TabOption';
+
+describe('TabOption', () => {
+  const onSelectMock = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('rendering', () => {
+    it('should render the component correctly with default props', () => {
+      const component = render(
+        <TabOption id="test-id" onSelect={onSelectMock} />
+      );
+
+      expect(component).toMatchSnapshot();
+    });
+
+    it('should render with label', () => {
+      render(
+        <TabOption id="test-id" label="Test Label" onSelect={onSelectMock} />
+      );
+
+      expect(screen.getByText('Test Label')).toBeInTheDocument();
+    });
+
+    it('should render with icon', () => {
+      const icon = <span data-testid="test-icon">Icon</span>;
+      render(<TabOption id="test-id" icon={icon} onSelect={onSelectMock} />);
+
+      expect(screen.getByTestId('test-icon')).toBeInTheDocument();
+    });
+
+    it('should render with both label and icon', () => {
+      const icon = <span data-testid="test-icon">Icon</span>;
+      render(
+        <TabOption
+          id="test-id"
+          label="Test Label"
+          icon={icon}
+          onSelect={onSelectMock}
+        />
+      );
+
+      expect(screen.getByText('Test Label')).toBeInTheDocument();
+      expect(screen.getByTestId('test-icon')).toBeInTheDocument();
+    });
+
+    it('should render with correct aria-label', () => {
+      render(<TabOption id="test-id" onSelect={onSelectMock} />);
+
+      const button = screen.getByRole('button', { name: 'test-id button' });
+      expect(button).toBeInTheDocument();
+    });
+  });
+
+  describe('selected state styling', () => {
+    it('should apply selected styles when isSelected is true and isDefault is true', () => {
+      render(
+        <TabOption
+          id="test-id"
+          isSelected={true}
+          isDefault={true}
+          onSelect={onSelectMock}
+        />
+      );
+
+      const button = screen.getByRole('button');
+      expect(button).toHaveClass('text-white dark:text-black');
+    });
+
+    it('should apply selected styles when isSelected is true and isDefault is false', () => {
+      render(
+        <TabOption
+          id="test-id"
+          isSelected={true}
+          isDefault={false}
+          onSelect={onSelectMock}
+        />
+      );
+
+      const button = screen.getByRole('button');
+      expect(button).toHaveClass('text-white');
+      expect(button).not.toHaveClass('dark:text-black');
+    });
+
+    it('should not apply selected styles when isSelected is false', () => {
+      render(
+        <TabOption
+          id="test-id"
+          isSelected={false}
+          isDefault={true}
+          onSelect={onSelectMock}
+        />
+      );
+
+      const button = screen.getByRole('button');
+      expect(button).not.toHaveClass('text-white');
+      expect(button).not.toHaveClass('dark:text-black');
+    });
+  });
+
+  describe('behavior', () => {
+    it('should call onSelect when clicked and not selected', () => {
+      render(
+        <TabOption id="test-id" isSelected={false} onSelect={onSelectMock} />
+      );
+
+      const button = screen.getByRole('button');
+      fireEvent.click(button);
+
+      expect(onSelectMock).toHaveBeenCalledTimes(1);
+      expect(onSelectMock).toHaveBeenCalledWith('test-id');
+    });
+
+    it('should not call onSelect when clicked and already selected', () => {
+      render(
+        <TabOption id="test-id" isSelected={true} onSelect={onSelectMock} />
+      );
+
+      const button = screen.getByRole('button');
+      fireEvent.click(button);
+
+      expect(onSelectMock).not.toHaveBeenCalled();
+    });
+
+    it('should call onSelect with correct id when multiple options exist', () => {
+      const onSelect1 = jest.fn();
+      const onSelect2 = jest.fn();
+
+      render(
+        <>
+          <TabOption id="option-1" isSelected={false} onSelect={onSelect1} />
+          <TabOption id="option-2" isSelected={false} onSelect={onSelect2} />
+        </>
+      );
+
+      const buttons = screen.getAllByRole('button');
+      fireEvent.click(buttons[0]);
+
+      expect(onSelect1).toHaveBeenCalledTimes(1);
+      expect(onSelect1).toHaveBeenCalledWith('option-1');
+      expect(onSelect2).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/components/atoms/TabGroup/__snapshots__/TabOption.test.tsx.snap
+++ b/src/components/atoms/TabGroup/__snapshots__/TabOption.test.tsx.snap
@@ -1,0 +1,72 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`TabOption rendering should render the component correctly with default props 1`] = `
+{
+  "asFragment": [Function],
+  "baseElement": <body>
+    <div>
+      <button
+        aria-label="test-id button"
+        class="relative z-10 flex h-7 w-7 items-center justify-center text-xs text-neutral-600 hover:cursor-pointer dark:text-white"
+      />
+    </div>
+  </body>,
+  "container": <div>
+    <button
+      aria-label="test-id button"
+      class="relative z-10 flex h-7 w-7 items-center justify-center text-xs text-neutral-600 hover:cursor-pointer dark:text-white"
+    />
+  </div>,
+  "debug": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
+`;


### PR DESCRIPTION
- Add comprehensive test coverage for TabOption component
- Test rendering with different props (label, icon, both)
- Test selected state styling variations
- Test click behavior and onSelect callback
- Achieve 100% code coverage for TabOption component